### PR TITLE
Feature/allow queryid visible

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function graphQLPersistedDocumentLoader(content) {
     // If no deps, just try to generate the document id from the
     // source returned from graphql-tag loader result. This will
     // add an id only if the source contains an operation.
-    content = tryAddDocumentId(options, content, this._module._graphQLQuerySource);
+    content = tryAddDocumentId(options, content, this._module);
     return content;
   }
 
@@ -61,7 +61,7 @@ module.exports = function graphQLPersistedDocumentLoader(content) {
       // with this module's query source, we can send all that to
       // generate the document id, if the resulting source
       // is for an operation.
-      content = tryAddDocumentId(options, content, this._module._graphQLQuerySource);
+      content = tryAddDocumentId(options, content, this._module);
     } catch (e) {
       callback(e);
     }
@@ -73,7 +73,8 @@ module.exports = function graphQLPersistedDocumentLoader(content) {
   });
 };
 
-function tryAddDocumentId(options, content, querySource) {
+function tryAddDocumentId(options, content, module) {
+  const querySource = module._graphQLQuerySource
   const queryMap = new ExtractGQL({
     queryTransformers: [options.addTypename && queryTransformers.addTypenameTransformer].filter(Boolean)
   }).createOutputMapFromString(querySource);
@@ -86,7 +87,7 @@ function tryAddDocumentId(options, content, querySource) {
     content += `${os.EOL}doc.documentId = ${JSON.stringify(queryId)}`;
 
     // Make the generated queryId visible for other modules 
-    this._module._graphQLQueryId = queryId
+    module._graphQLQueryId = queryId
   }
 
   return content;

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function tryAddDocumentId(options, content, querySource) {
     content += `${os.EOL}doc.documentId = ${JSON.stringify(queryId)}`;
 
     // Make the generated queryId visible for other modules 
-    this._module_._graphQLQueryId = queryId
+    this._module._graphQLQueryId = queryId
   }
 
   return content;

--- a/index.js
+++ b/index.js
@@ -84,6 +84,9 @@ function tryAddDocumentId(options, content, querySource) {
   } else if (queries.length === 1) {
     const queryId = generateIdForQuery(options, Object.keys(queryMap)[0]);
     content += `${os.EOL}doc.documentId = ${JSON.stringify(queryId)}`;
+
+    // Make the generated queryId visible for other modules 
+    this._module_._graphQLQueryId = queryId
   }
 
   return content;

--- a/index.js
+++ b/index.js
@@ -83,11 +83,13 @@ function tryAddDocumentId(options, content, module) {
   if (queries.length > 1) {
     throw new Error('Only one operation per file is allowed');
   } else if (queries.length === 1) {
-    const queryId = generateIdForQuery(options, Object.keys(queryMap)[0]);
+    const finalQueryStr = Object.keys(queryMap)[0]
+    const queryId = generateIdForQuery(options, finalQueryStr);
     content += `${os.EOL}doc.documentId = ${JSON.stringify(queryId)}`;
 
-    // Make the generated queryId visible for other modules 
+    // Make the generated queryId and final queryStr visible for other modules  
     module._graphQLQueryId = queryId
+    module._graphQLQuerySource = finalQueryStr
   }
 
   return content;


### PR DESCRIPTION
This pull solves the following issues
- Exports the generated id in _graphQLQueryId so other modules can use it
- Updates _graphQLQuerySource with the final generated source (after applying modifiers, like __typename)