### PR TITLE
Adding doc.documentId below module.export breaks eval()

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,8 @@ function tryAddDocumentId(options, content, querySource) {
     throw new Error('Only one operation per file is allowed');
   } else if (queries.length === 1) {
     const queryId = generateIdForQuery(options, Object.keys(queryMap)[0]);
-    content += `${os.EOL}doc.documentId = ${JSON.stringify(queryId)}`;
+    var insertionIdnex = content.lastIndexOf("module.exports");
+    content.substring(0, insertionIdnex) + `${os.EOL}doc.documentId = ${JSON.stringify(queryId)};${os.EOL}` + content.substring(insertionIdnex)
   }
 
   return content;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-persisted-document-loader",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Webpack loader that adds a documentId to a compiled graphql document, which can be used when persisting/retrieving documents",
   "main": "index.js",
   "repository": "git@github.com:leoasis/graphql-persisted-document-loader.git",


### PR DESCRIPTION
see https://github.com/leoasis/graphql-persisted-document-loader/issues/3