### PR TITLE
Support multiple operations per file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To solve this problem, this loader works after the [graphql-tag loader](https://
 
 ## Installation and setup
 
-You need to have the [graphql-tag](https://github.com/apollographql/graphql-tag) package installed.
+You need to have the [graphql-tag](https://github.com/apollographql/graphql-tag) *(>= v2.8.0)* package installed.
 
 First install this package
 

--- a/example/app.js
+++ b/example/app.js
@@ -7,8 +7,11 @@ el.innerHTML = `
   <h1>Document id: ${query.documentId}</h1>
   <pre>${JSON.stringify(query, null, 4)}</pre>
   <hr />
-  <h1>Document id: ${queryWithDeps.documentId}</h1>
-  <pre>${JSON.stringify(queryWithDeps, null, 4)}</pre>
+  <h1>Document id: ${queryWithDeps.SomeQuery.documentId}</h1>
+  <pre>${JSON.stringify(queryWithDeps.SomeQuery, null, 4)}</pre>
+  <hr />
+  <h1>Document id: ${queryWithDeps.SomeMutation.documentId}</h1>
+  <pre>${JSON.stringify(queryWithDeps.SomeMutation, null, 4)}</pre>
 `;
 
 document.body.appendChild(el);

--- a/example/query-with-deps.graphql
+++ b/example/query-with-deps.graphql
@@ -7,3 +7,11 @@ query SomeQuery {
     ...Dep
   }
 }
+
+mutation SomeMutation {
+  foo {
+    bar
+    baz
+    ...Dep
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   "dependencies": {
     "loader-utils": "^1.1.0",
     "persistgraphql": "^0.3.11"
+  },
+  "peerDependencies": {
+    "graphql-tag": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "webpack-dev-server --config ./example/webpack.config.js"
   },
   "devDependencies": {
-    "graphql-tag": "^2.5.0",
+    "graphql-tag": "^2.9.2",
     "webpack": "^3.8.1",
     "webpack-dev-server": "^2.9.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,9 +1156,13 @@ graphql-anywhere@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-3.1.0.tgz#3ea0d8e8646b5cee68035016a9a7557c15c21e96"
 
-graphql-tag@^2.0.0, graphql-tag@^2.4.2, graphql-tag@^2.5.0:
+graphql-tag@^2.0.0, graphql-tag@^2.4.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.5.0.tgz#b43bfd8b5babcd2c205ad680c03e98b238934e0f"
+
+graphql-tag@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.9.2.tgz#2f60a5a981375f430bf1e6e95992427dc18af686"
 
 "graphql@>=0.9.4 <0.11", graphql@^0.10.0, graphql@^0.10.3:
   version "0.10.5"


### PR DESCRIPTION
From issue: https://github.com/leoasis/graphql-persisted-document-loader/issues/5

I needed to upgrade graphql-tag in order to have the `module.exports["MyQuery"]` at the end of the file, since was added after this lib was made.